### PR TITLE
feat: allow comments in parser

### DIFF
--- a/core/ast/src/parser.rs
+++ b/core/ast/src/parser.rs
@@ -113,7 +113,7 @@ impl Parser {
                 Some(Stmt::Block(block))
             }
             TokenKind::Return => self.parse_return()?,
-            TokenKind::Semicolon => {
+            TokenKind::Semicolon | TokenKind::Comment => {
                 self.consume();
                 None
             }


### PR DESCRIPTION
Solves #6 
```rs
use { println } from "std::io";

export fn main() -> int {
    //throw "Hello, World!";
    println("{} + {} = {}, 123");

    return 0;
}

main();
```

Now comments will be skipped in the parsing process so they won't panic