### PR TITLE
Add access expr

### DIFF
--- a/core/ast/src/lexer/mod.rs
+++ b/core/ast/src/lexer/mod.rs
@@ -148,7 +148,7 @@ impl Lexer {
                                 next.to_string(),
                                 TextSpan::new(self.position, self.position, next.to_string()),
                             )
-                            .into())
+                                .into())
                         }
                     }
                     self.consume();
@@ -241,6 +241,8 @@ impl Lexer {
                                 self.consume();
                             }
                             TokenKind::Comment
+                        } else if self.match_next('=') {
+                            TokenKind::DivideEquals
                         } else {
                             TokenKind::Slash
                         }
@@ -271,6 +273,8 @@ impl Lexer {
                         self.consume();
                         if self.match_next('*') {
                             TokenKind::DoubleAsterisk
+                        } else if self.match_next('=') {
+                            TokenKind::MultiplyEquals
                         } else {
                             TokenKind::Asterisk
                         }
@@ -331,7 +335,7 @@ impl Lexer {
                             c.to_string(),
                             TextSpan::new(start_pos, self.position, c.to_string()),
                         )
-                        .into());
+                            .into());
                     }
                 };
 

--- a/core/ast/src/lexer/mod.rs
+++ b/core/ast/src/lexer/mod.rs
@@ -217,19 +217,7 @@ impl Lexer {
                     '[' => TokenKind::LeftBracket,
                     ']' => TokenKind::RightBracket,
                     ',' => TokenKind::Comma,
-                    '.' => {
-                        if self.match_next('.') {
-                            self.consume();
-                            if self.match_next('.') {
-                                self.consume();
-                                TokenKind::TripleDot
-                            } else {
-                                TokenKind::DoubleDot
-                            }
-                        } else {
-                            TokenKind::Dot
-                        }
-                    }
+                    '.' => self.lex_potential_triple('.', TokenKind::Dot, TokenKind::DoubleDot, TokenKind::TripleDot),
                     ':' => TokenKind::Colon,
                     ';' => TokenKind::Semicolon,
                     '/' => {
@@ -281,54 +269,12 @@ impl Lexer {
                     }
                     '%' => TokenKind::Percent,
                     '^' => TokenKind::Caret,
-                    '!' => {
-                        self.consume();
-                        if self.match_next('=') {
-                            TokenKind::BangEquals
-                        } else {
-                            TokenKind::Bang
-                        }
-                    }
-                    '=' => {
-                        self.consume();
-                        if self.match_next('=') {
-                            TokenKind::EqualsEquals
-                        } else {
-                            TokenKind::Equals
-                        }
-                    }
-                    '<' => {
-                        self.consume();
-                        if self.match_next('=') {
-                            TokenKind::LessThanEquals
-                        } else {
-                            TokenKind::LessThan
-                        }
-                    }
-                    '>' => {
-                        self.consume();
-                        if self.match_next('=') {
-                            TokenKind::GreaterThanEquals
-                        } else {
-                            TokenKind::GreaterThan
-                        }
-                    }
-                    '&' => {
-                        self.consume();
-                        if self.match_next('&') {
-                            TokenKind::And
-                        } else {
-                            TokenKind::Ampersand
-                        }
-                    }
-                    '|' => {
-                        self.consume();
-                        if self.match_next('|') {
-                            TokenKind::Or
-                        } else {
-                            TokenKind::Pipe
-                        }
-                    }
+                    '!' => self.lex_potential_double('=', TokenKind::Bang, TokenKind::BangEquals),
+                    '=' => self.lex_potential_double('=', TokenKind::Equals, TokenKind::EqualsEquals),
+                    '<' => self.lex_potential_double('<', TokenKind::LessThan, TokenKind::LessThanEquals),
+                    '>' => self.lex_potential_double('=', TokenKind::GreaterThan, TokenKind::GreaterThanEquals),
+                    '&' => self.lex_potential_double('&', TokenKind::Ampersand, TokenKind::And),
+                    '|' => self.lex_potential_double('|', TokenKind::Pipe, TokenKind::Or),
                     _ => {
                         self.consume();
                         return Err(InvalidToken(
@@ -351,6 +297,35 @@ impl Lexer {
             )))
         } else {
             Ok(None)
+        }
+    }
+
+    pub fn lex_potential_double(&mut self, expected: char, one_char: TokenKind, double_char: TokenKind) -> TokenKind {
+        if let Some(next) = self.peek() {
+            if next == expected {
+                self.consume();
+                double_char
+            } else {
+                one_char
+            }
+        } else {
+            one_char
+        }
+    }
+
+    pub fn lex_potential_triple(&mut self, expected: char, one_char: TokenKind, double_char: TokenKind, triple_char: TokenKind) -> TokenKind {
+        match self.peek() {
+            Some(next) if next == expected => {
+                self.consume();
+                match self.peek() {
+                    Some(next) if next == expected => {
+                        self.consume();
+                        triple_char
+                    }
+                    _ => double_char,
+                }
+            }
+            _ => one_char,
         }
     }
 
@@ -408,4 +383,61 @@ impl Lexer {
 pub enum NumberType {
     Integer,
     Float,
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::Source;
+
+    #[test]
+    fn test_single_dot() {
+        let source = Source::from_string("arr.len();".to_string());
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.lex().unwrap();
+
+        let expected_kinds = vec![
+            TokenKind::Identifier, // arr
+            TokenKind::Dot,        // .
+            TokenKind::Identifier, // len
+            TokenKind::LeftParen,  // (
+            TokenKind::RightParen, // )
+            TokenKind::Semicolon,  // ;
+        ];
+
+        let actual_kinds: Vec<TokenKind> = tokens.iter().map(|t| t.kind.clone()).collect();
+
+        assert_eq!(actual_kinds, expected_kinds);
+    }
+
+    #[test]
+    fn test_double_dot() {
+        let source = Source::from_string("..".to_string());
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.lex().unwrap();
+
+        let expected_kinds = vec![
+            TokenKind::DoubleDot, // ..
+        ];
+
+        let actual_kinds: Vec<TokenKind> = tokens.iter().map(|t| t.kind.clone()).collect();
+
+        assert_eq!(actual_kinds, expected_kinds);
+    }
+
+    #[test]
+    fn test_triple_dot() {
+        let source = Source::from_string("...".to_string());
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.lex().unwrap();
+
+        let expected_kinds = vec![
+            TokenKind::TripleDot, // ...
+        ];
+
+        let actual_kinds: Vec<TokenKind> = tokens.iter().map(|t| t.kind.clone()).collect();
+
+        assert_eq!(actual_kinds, expected_kinds);
+    }
 }

--- a/core/ast/src/lexer/token.rs
+++ b/core/ast/src/lexer/token.rs
@@ -101,6 +101,8 @@ impl Display for TokenKind {
             TokenKind::Decrement => write!(f, "--"),
             TokenKind::MinusEquals => write!(f, "-="),
             TokenKind::PlusEquals => write!(f, "+="),
+            TokenKind::MultiplyEquals => write!(f, "*="),
+            TokenKind::DivideEquals => write!(f, "/="),
             TokenKind::EOF => write!(f, "EOF"),
             TokenKind::Whitespace => write!(f, "Whitespace"),
             TokenKind::Bad => write!(f, "Bad"),
@@ -179,6 +181,8 @@ pub enum TokenKind {
     Decrement,         // --
     MinusEquals,       // -=
     PlusEquals,        // +=
+    MultiplyEquals,    // *=
+    DivideEquals,      // /=
 
     EOF,
     Whitespace,

--- a/core/ast/src/parser/statements.rs
+++ b/core/ast/src/parser/statements.rs
@@ -132,15 +132,12 @@ impl Parser {
         let if_token = self.consume();
 
         self.possible_check(TokenKind::LeftParen);
-
         let condition = self.parse_expr()?;
 
         self.possible_check(TokenKind::RightParen);
-
         self.expect(TokenKind::LeftBrace)?;
 
         let body = self.parse_block()?;
-
         self.expect(TokenKind::RightBrace)?;
 
         let mut elseif_blocks = vec![];
@@ -167,9 +164,7 @@ impl Parser {
                 });
             } else {
                 self.expect(TokenKind::LeftBrace)?;
-
                 let body = self.parse_block()?;
-
                 self.expect(TokenKind::RightBrace)?;
 
                 else_block = Some(ElseBlock {

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -2,8 +2,9 @@ extern crate core;
 
 pub mod context;
 pub mod module;
-mod natives;
+pub mod natives;
 pub mod vm;
+pub mod value;
 
 pub use roan_ast::*;
 pub use roan_error::{diagnostic::*, error::PulseError::*, span::*};

--- a/core/engine/src/module/mod.rs
+++ b/core/engine/src/module/mod.rs
@@ -407,7 +407,15 @@ impl Module {
             Expr::Access(access) => {
                 match access.access.clone() {
                     AccessKind::Field(field) => {
-                        unimplemented!("field access")
+                        let base = access.base.clone();
+
+                        self.interpret_expr(&base, ctx)?;
+                        let base = self.vm.pop().unwrap();
+
+                        self.interpret_expr(&field, ctx)?;
+                        let field = self.vm.pop().unwrap();
+
+                        Ok(base.access_field(field))
                     }
                     AccessKind::Index(index) => {
                         self.interpret_expr(&index, ctx)?;
@@ -440,7 +448,12 @@ impl Module {
                     }
                     Expr::Access(access) => {
                         match &access.access {
-                            AccessKind::Field(_) => {
+                            AccessKind::Field(field) => {
+                                let base = access.base.clone();
+
+                                self.interpret_expr(right, ctx)?;
+                                let new_val = self.vm.pop().unwrap();
+                                println!("{:?}", new_val);
                                 unimplemented!("field access")
                             }
                             AccessKind::Index(index_expr) => {
@@ -459,7 +472,7 @@ impl Module {
                                         return Err(PulseError::IndexOutOfBounds(
                                             idx,
                                             vec.len(),
-                                            index_expr.span()
+                                            index_expr.span(),
                                         )
                                             .into());
                                     }

--- a/core/engine/src/natives/io.rs
+++ b/core/engine/src/natives/io.rs
@@ -1,4 +1,5 @@
-use crate::{native_function, vm::value::Value};
+use crate::{native_function};
+use crate::value::Value;
 
 native_function!(fn __print(
     msg: String,

--- a/core/engine/src/value/methods/vec.rs
+++ b/core/engine/src/value/methods/vec.rs
@@ -1,0 +1,10 @@
+use crate::native_function;
+use crate::value::Value;
+
+native_function!(
+    fn __vec_len(
+        vec: Vec
+    ) {
+        Value::Int(vec.len() as i64)
+    }
+);

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -1,6 +1,16 @@
-use roan_ast::{AccessKind, Literal, LiteralType};
+use std::collections::HashMap;
+use roan_ast::{AccessKind, Expr, GetSpan, Literal, LiteralType};
 use std::fmt::{Debug, Display};
 use std::ops;
+use crate::vm::native_fn::NativeFunction;
+use anyhow::Result;
+use roan_error::error::PulseError::{InvalidPropertyAccess, PropertyNotFoundError};
+use crate::value::methods::vec::__vec_len;
+use crate::value::Value::Vec;
+
+pub mod methods {
+    pub mod vec;
+}
 
 #[derive(Clone)]
 pub enum Value {
@@ -8,9 +18,22 @@ pub enum Value {
     Float(f64),
     Bool(bool),
     String(String),
-    Vec(Vec<Value>),
+    Vec(std::vec::Vec<Value>),
     Null,
     Void,
+}
+
+impl Value {
+    pub fn builtin_methods(&self) -> HashMap<String, NativeFunction> {
+        match self {
+            Value::Vec(_) => {
+                let mut map = HashMap::new();
+                map.insert("len".to_string(), __vec_len());
+                map
+            }
+            _ => HashMap::new(),
+        }
+    }
 }
 
 impl Debug for Value {
@@ -189,21 +212,6 @@ impl Value {
         match self {
             Value::Vec(v) => match index {
                 Value::Int(i) => v.get(i as usize).cloned().unwrap_or(Value::Null),
-                _ => Value::Null,
-            },
-            _ => Value::Null
-        }
-    }
-
-    pub fn access_field(&self, field: Value) -> Self {
-        match self {
-            Value::Vec(v) => match field {
-                Value::String(s) => {
-                    if s == "len" {
-                        return Value::Int(v.len() as i64);
-                    }
-                    Value::Null
-                }
                 _ => Value::Null,
             },
             _ => Value::Null

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -1,8 +1,7 @@
 pub mod native_fn;
-pub mod value;
 
-use crate::vm::value::Value;
 use roan_error::frame::Frame;
+use crate::value::Value;
 
 /// Virtual machine for executing Roan code.
 #[derive(Debug, Clone)]

--- a/core/engine/src/vm/native_fn.rs
+++ b/core/engine/src/vm/native_fn.rs
@@ -1,9 +1,10 @@
-use crate::vm::value::Value;
 use roan_ast::FnParam;
 use std::{
     fmt,
     fmt::{Display, Formatter},
 };
+use log::debug;
+use crate::value::Value;
 
 #[derive(Debug, Clone)]
 pub struct NativeFunctionParam {
@@ -30,6 +31,23 @@ impl NativeFunction {
             func,
             params,
         }
+    }
+
+    pub fn call(&mut self, args: Vec<Value>) -> anyhow::Result<Value> {
+        debug!("Executing native function: {}", self.name);
+
+        let mut params = vec![];
+        for (param, val) in self.params.iter().zip(args.clone()) {
+            if param.is_rest {
+                let rest = args.iter().skip(self.params.len() - 1).cloned().collect();
+
+                params.push(Value::Vec(rest));
+            } else {
+                params.push(val);
+            }
+        }
+
+        Ok((self.func)(params))
     }
 }
 

--- a/core/engine/src/vm/value.rs
+++ b/core/engine/src/vm/value.rs
@@ -1,4 +1,4 @@
-use roan_ast::{Literal, LiteralType};
+use roan_ast::{AccessKind, Literal, LiteralType};
 use std::fmt::{Debug, Display};
 use std::ops;
 
@@ -189,6 +189,21 @@ impl Value {
         match self {
             Value::Vec(v) => match index {
                 Value::Int(i) => v.get(i as usize).cloned().unwrap_or(Value::Null),
+                _ => Value::Null,
+            },
+            _ => Value::Null
+        }
+    }
+
+    pub fn access_field(&self, field: Value) -> Self {
+        match self {
+            Value::Vec(v) => match field {
+                Value::String(s) => {
+                    if s == "len" {
+                        return Value::Int(v.len() as i64);
+                    }
+                    Value::Null
+                }
                 _ => Value::Null,
             },
             _ => Value::Null

--- a/core/engine/src/vm/value.rs
+++ b/core/engine/src/vm/value.rs
@@ -183,3 +183,15 @@ impl Value {
         }
     }
 }
+
+impl Value {
+    pub fn access_index(&self, index: Self) -> Self {
+        match self {
+            Value::Vec(v) => match index {
+                Value::Int(i) => v.get(i as usize).cloned().unwrap_or(Value::Null),
+                _ => Value::Null,
+            },
+            _ => Value::Null
+        }
+    }
+}

--- a/core/error/src/diagnostic.rs
+++ b/core/error/src/diagnostic.rs
@@ -204,12 +204,20 @@ pub fn print_diagnostic(err: anyhow::Error, content: Option<String>) {
             PulseError::ModuleNotFoundError(_, span)
             | PulseError::UndefinedFunctionError(_, span)
             | PulseError::VariableNotFoundError(_, span)
-            | PulseError::ImportError(_, span) | PulseError::TypeMismatch(_, span) | PulseError::InvalidAssignment(_, span) => Diagnostic {
+            | PulseError::ImportError(_, span) | PulseError::PropertyNotFoundError(_, span) | PulseError::TypeMismatch(_, span) | PulseError::InvalidAssignment(_, span) => Diagnostic {
                 title: err_str,
                 text: None,
                 level: Level::Error,
                 location: Some(span.clone()),
                 hint: None,
+                content,
+            },
+            PulseError::InvalidPropertyAccess(span) => Diagnostic {
+                title: err_str,
+                text: None,
+                level: Level::Error,
+                location: Some(span.clone()),
+                hint: Some("Only string literals or call expressions are allowed".to_string()),
                 content,
             },
             PulseError::IndexOutOfBounds(_, _, span) => Diagnostic {

--- a/core/error/src/diagnostic.rs
+++ b/core/error/src/diagnostic.rs
@@ -57,7 +57,7 @@ impl Diagnostic {
             ": ".dimmed(),
             self.title
         )
-        .expect("Error writing level");
+            .expect("Error writing level");
 
         if let Some(location) = &self.location {
             if let Some(content) = &self.content {
@@ -169,7 +169,7 @@ pub fn print_diagnostic(err: anyhow::Error, content: Option<String>) {
             PulseError::InvalidToken(_, span)
             | PulseError::SemanticError(_, span)
             | PulseError::UnexpectedToken(_, span)
-            | PulseError::InvalidEscapeSequence(_, span) | PulseError::NonBooleanCondition(_,span) => Diagnostic {
+            | PulseError::InvalidEscapeSequence(_, span) | PulseError::NonBooleanCondition(_, span) => Diagnostic {
                 title: err_str,
                 text: None,
                 level: Level::Error,
@@ -204,7 +204,15 @@ pub fn print_diagnostic(err: anyhow::Error, content: Option<String>) {
             PulseError::ModuleNotFoundError(_, span)
             | PulseError::UndefinedFunctionError(_, span)
             | PulseError::VariableNotFoundError(_, span)
-            | PulseError::ImportError(_, span) => Diagnostic {
+            | PulseError::ImportError(_, span) | PulseError::TypeMismatch(_, span) | PulseError::InvalidAssignment(_, span) => Diagnostic {
+                title: err_str,
+                text: None,
+                level: Level::Error,
+                location: Some(span.clone()),
+                hint: None,
+                content,
+            },
+            PulseError::IndexOutOfBounds(_, _, span) => Diagnostic {
                 title: err_str,
                 text: None,
                 level: Level::Error,

--- a/core/error/src/error.rs
+++ b/core/error/src/error.rs
@@ -37,4 +37,10 @@ pub enum PulseError {
     InvalidEscapeSequence(String, TextSpan),
     #[error("{0} does not evaluate to a boolean.")]
     NonBooleanCondition(String, TextSpan),
+    #[error("Index out of bounds: {0} >= {1}")]
+    IndexOutOfBounds(usize, usize , TextSpan),
+    #[error("Type mismatch: {0}")]
+    TypeMismatch(String, TextSpan),
+    #[error("Invalid assigment {0}")]
+    InvalidAssignment(String, TextSpan),
 }

--- a/core/error/src/error.rs
+++ b/core/error/src/error.rs
@@ -43,4 +43,8 @@ pub enum PulseError {
     TypeMismatch(String, TextSpan),
     #[error("Invalid assigment {0}")]
     InvalidAssignment(String, TextSpan),
+    #[error("Attempted to access non-existent property: {0}")]
+    PropertyNotFoundError(String, TextSpan),
+    #[error("Invalid property access")]
+    InvalidPropertyAccess(TextSpan),
 }

--- a/playground/src/main.roan
+++ b/playground/src/main.roan
@@ -10,7 +10,8 @@ export fn main() -> int {
     str = "Hello, Roan!";
     println("str = {}", str);
 
-    //let len = arr.len();
+    let len = arr.len();
+    println("arr.len() = {}", len);
 
     return 0;
 }

--- a/playground/src/main.roan
+++ b/playground/src/main.roan
@@ -1,7 +1,16 @@
-use { println } from "std::io";
+use { println } from "std::io"
 
 export fn main() -> int {
-    println("{}", 10 | 3);
+    let arr = [1, 2, 3, 4, 5];
+    let str = "Hello, World!";
+    arr[0] = 10;
+
+    println("arr[0] = {}", arr[0]);
+
+    str = "Hello, Roan!";
+    println("str = {}", str);
+
+    //let len = arr.len();
 
     return 0;
 }


### PR DESCRIPTION
```rs
export fn main() -> int {
    let arr = [1, 2, 3, 4, 5];

    arr[0] = 10;

    let len = arr.len();

    return 0;
}

main();
```

This pr doesn't implement the whole functionality. It only implmenets index access for vectors and field access for builtin types as we currently don't have support for objects/structs.