### PR TITLE
fix: implement PartialEq for Value::Char

### DIFF
--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -248,6 +248,7 @@ impl PartialEq for Value {
             }
             (Value::Null, Value::Null) => true,
             (Value::Void, Value::Void) => true,
+            (Value::Char(a), Value::Char(b)) => a == b,
             _ => false,
         }
     }


### PR DESCRIPTION
### TL;DR

Added equality comparison for `Char` values in the `Value` enum.

### What changed?

Implemented the `PartialEq` trait for `Value::Char` variants in the `PartialEq` implementation for the `Value` enum. This allows direct comparison of `Char` values within the `Value` type.
