### PR TITLE
tests: bring back string.chars() test

### DIFF
--- a/core/engine/src/value/methods/string.rs
+++ b/core/engine/src/value/methods/string.rs
@@ -234,27 +234,23 @@ mod tests {
         );
     }
 
-    // assertion `left == right` failed
-    //   left: Vec([Char('H'), Char('e'), Char('l'), Char('l'), Char('o')])
-    //  right: Vec([Char('H'), Char('e'), Char('l'), Char('l'), Char('o')])
-    // The left and right are equal, but the assertion failed.
-    // #[test]
-    // fn test_string_chars() {
-    //     let result = __string_chars()
-    //         .call(vec![Value::String("Hello".to_string())])
-    //         .unwrap();
-    //
-    //     assert_eq!(
-    //         result,
-    //         Value::Vec(vec![
-    //             Value::Char('H'),
-    //             Value::Char('e'),
-    //             Value::Char('l'),
-    //             Value::Char('l'),
-    //             Value::Char('o')
-    //         ])
-    //     );
-    // }
+    #[test]
+    fn test_string_chars() {
+        let result = __string_chars()
+            .call(vec![Value::String("Hello".to_string())])
+            .unwrap();
+
+        assert_eq!(
+            result,
+            Value::Vec(vec![
+                Value::Char('H'),
+                Value::Char('e'),
+                Value::Char('l'),
+                Value::Char('l'),
+                Value::Char('o')
+            ])
+        );
+    }
 
     #[test]
     fn test_string_contains() {


### PR DESCRIPTION
### TL;DR

Uncommented and re-enabled the `test_string_chars` test function.

### What changed?

The previously commented-out `test_string_chars` function has been uncommented and reintroduced into the test suite. This test verifies the functionality of the `__string_chars()` method, ensuring it correctly converts a string into a vector of individual characters.
