### PR TITLE
tests: update test_combine_empty to adjust to new behaviour

### DIFF
--- a/core/error/src/span.rs
+++ b/core/error/src/span.rs
@@ -168,9 +168,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_combine_empty() {
-        TextSpan::combine(vec![]);
+        assert_eq!(TextSpan::combine(vec![]), None);
     }
 
     #[test]


### PR DESCRIPTION
### TL;DR

Modified test case for `TextSpan::combine`

### What changed?

- Updated the `test_combine_empty` test case to assert that `TextSpan::combine` returns `None` for an empty vector input.
- Removed the `#[should_panic]` attribute from the `test_combine_empty` test.
