### PR TITLE
feat: implement struct methods and improve module handling

### DIFF
--- a/core/engine/src/interpreter/stmt.rs
+++ b/core/engine/src/interpreter/stmt.rs
@@ -1,6 +1,6 @@
 use crate::{
     context::Context,
-    module::{ExportType, Module, StoredFunction},
+    module::{ExportType, Module, StoredFunction, StoredStruct},
     value::Value,
     vm::VM,
 };
@@ -87,7 +87,10 @@ impl Module {
                 }
             }
             Stmt::Struct(struct_stmt) => {
-                self.structs.push(struct_stmt.clone());
+                self.structs.push(StoredStruct {
+                    def: struct_stmt.clone(),
+                    defining_module: Arc::clone(&Arc::new(Mutex::new(self.clone()))),
+                });
 
                 if struct_stmt.public {
                     self.exports.push((
@@ -120,15 +123,14 @@ impl Module {
     pub fn interpret_struct_impl(&mut self, impl_stmt: StructImpl) -> Result<()> {
         let struct_name = impl_stmt.struct_name.literal();
 
-        let mut struct_def = self.get_struct(&struct_name, impl_stmt.struct_name.span.clone())?;
-        struct_def.impls.push(impl_stmt.clone());
-
+        let mut found_struct = self.get_struct(&struct_name, impl_stmt.struct_name.span.clone())?;
+        found_struct.def.impls.push(impl_stmt.clone());
         if let Some(existing_struct) = self
             .structs
             .iter_mut()
-            .find(|s| s.name.literal() == struct_name)
+            .find(|s| s.def.name.literal() == struct_name)
         {
-            *existing_struct = struct_def;
+            *existing_struct = found_struct;
 
             if let Some(export) = self.exports.iter_mut().find(|(n, _)| n == &struct_name) {
                 if let ExportType::Struct(s) = &mut export.1 {
@@ -152,6 +154,7 @@ impl Module {
         let trait_def = self.get_trait(&trait_name, impl_stmt.trait_name.span.clone())?;
 
         if struct_def
+            .def
             .trait_impls
             .iter()
             .any(|t| t.trait_name.literal() == trait_name)
@@ -180,12 +183,12 @@ impl Module {
             .into());
         }
 
-        struct_def.trait_impls.push(impl_stmt.clone());
+        struct_def.def.trait_impls.push(impl_stmt.clone());
 
         if let Some(existing_struct) = self
             .structs
             .iter_mut()
-            .find(|s| s.name.literal() == for_name)
+            .find(|s| s.def.name.literal() == for_name)
         {
             *existing_struct = struct_def;
 
@@ -208,11 +211,11 @@ impl Module {
             .ok_or_else(|| PulseError::TraitNotFoundError(name.into(), span))?)
     }
 
-    pub fn get_struct(&self, name: &str, span: TextSpan) -> Result<Struct> {
+    pub fn get_struct(&self, name: &str, span: TextSpan) -> Result<StoredStruct> {
         Ok(self
             .structs
             .iter()
-            .find(|s| s.name.literal() == name)
+            .find(|s| s.def.name.literal() == name)
             .cloned()
             .ok_or_else(|| PulseError::StructNotFoundError(name.into(), span))?)
     }
@@ -421,7 +424,10 @@ impl Module {
                         });
                     }
                     ExportType::Struct(s) => {
-                        self.structs.push(s.clone());
+                        self.structs.push(StoredStruct {
+                            def: s.clone(),
+                            defining_module: Arc::clone(&module),
+                        });
                     }
                     ExportType::Trait(t) => {
                         self.traits.push(t.clone());

--- a/core/engine/src/module/mod.rs
+++ b/core/engine/src/module/mod.rs
@@ -18,6 +18,12 @@ use tracing::debug;
 pub mod loaders;
 
 #[derive(Debug, Clone)]
+pub struct StoredStruct {
+    pub(crate) def: Struct,
+    pub(crate) defining_module: Arc<Mutex<Module>>,
+}
+
+#[derive(Debug, Clone)]
 pub enum ExportType {
     Function(Fn),
     Trait(TraitDef),
@@ -43,7 +49,7 @@ pub struct Module {
     pub(crate) functions: Vec<StoredFunction>,
     pub(crate) exports: Vec<(String, ExportType)>,
     pub(crate) scopes: Vec<HashMap<String, Value>>,
-    pub(crate) structs: Vec<Struct>,
+    pub(crate) structs: Vec<StoredStruct>,
     pub(crate) traits: Vec<TraitDef>,
 }
 

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     entries,
+    module::StoredStruct,
     value::methods::{
         char::{
             __char_escape_default, __char_escape_unicode, __char_from_digit, __char_is_alphabetic,
@@ -45,7 +46,7 @@ pub enum Value {
     Char(char),
     String(String),
     Vec(Vec<Value>),
-    Struct(Struct, HashMap<String, Value>),
+    Struct(StoredStruct, HashMap<String, Value>),
     Null,
     Void,
 }
@@ -374,7 +375,7 @@ impl Value {
                     format!("{}[]", vals[0].type_name())
                 }
             }
-            Value::Struct(struct_def, _) => struct_def.name.literal(),
+            Value::Struct(struct_def, _) => struct_def.def.name.literal(),
             Value::Null => "null".to_string(),
             Value::Void => "void".to_string(),
             Value::Char(_) => "char".to_string(),

--- a/playground/src/main.roan
+++ b/playground/src/main.roan
@@ -1,12 +1,10 @@
-use { assert, println } from "std::debug"
+use { println } from "std::debug"
 use { Base64Encoder } from "std::base64";
 
 pub fn main() -> int {
-    assert(1 == 1, "1 is not equal to 1");
-
     let encoder = Base64Encoder::new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
 
-    println("{}", encoder);
+    println("{}", encoder.check());
 
     return 0;
 }


### PR DESCRIPTION
### TL;DR

Improved struct handling.

### What changed?

- Introduced `StoredStruct` to hold both the struct definition and its defining module.
- Updated struct-related operations to use `StoredStruct`.
- Removed `todo!` macro for unhandled expressions in the interpreter.
- Simplified variable names in struct constructor interpretation.
- Modified struct method and static method calls to use the defining module.
