### PR TITLE
add load_module to Context and use it to fix import issues

### DIFF
--- a/core/engine/src/context.rs
+++ b/core/engine/src/context.rs
@@ -123,6 +123,18 @@ impl Context {
         self.module_loader.borrow().get(name)
     }
 
+    /// Load a module from the context.
+    /// 
+    /// This function is different from `query_module` in that it will attempt to load the module from the cache
+    /// if it is not found it will try to resolve the path and load the module.
+    /// 
+    /// # Arguments
+    /// - `referrer` - The module that is requesting the module.
+    /// - `spec` - The name of the module to load.
+    pub fn load_module(&mut self, referrer: &Module, spec: &str) -> Result<Module> {
+        self.module_loader.borrow_mut().load(referrer, spec, self)
+    }
+    
     pub fn module_keys(&self) -> Vec<String> {
         self.module_loader.borrow().keys()
     }

--- a/core/engine/src/interpreter/stmt.rs
+++ b/core/engine/src/interpreter/stmt.rs
@@ -415,9 +415,9 @@ impl Module {
     pub fn interpret_use(&mut self, u: Use, ctx: &mut Context, vm: &mut VM) -> Result<()> {
         debug!("Interpreting use: {}", u.from.literal());
 
-        let mut loaded_module = ctx.query_module(&u.from.literal()).ok_or_else(|| {
-            ModuleNotFoundError(u.from.literal().to_string(), u.from.span.clone())
-        })?;
+        let mut loaded_module = ctx
+            .load_module(&self.clone(), &u.from.literal())
+            .map_err(|_| ModuleNotFoundError(u.from.literal().to_string(), u.from.span.clone()))?;
 
         match loaded_module.parse() {
             Ok(_) => {}

--- a/playground/src/main.roan
+++ b/playground/src/main.roan
@@ -19,6 +19,7 @@ impl Person {
 pub const person = Person::new("John Doe", 30, "Software Engineer");
 
 pub fn main() -> int {
+    println("Person: {}", person);
 
     return 0;
 }


### PR DESCRIPTION
### TL;DR

Added a new `load_module` function to the `Context` struct and updated the `interpret_use` method to use it.

### What changed?

- Added a new `load_module` function to the `Context` struct in `context.rs`. This function attempts to load a module from the cache or resolve and load it if not found.
- Updated the `interpret_use` method in `stmt.rs` to use the new `load_module` function instead of `query_module`.